### PR TITLE
URL substitute: old text is default for new text

### DIFF
--- a/app/win/main_tl.js
+++ b/app/win/main_tl.js
@@ -552,7 +552,7 @@ function actionURLSubstitute(node_id, node, unused_action_id, unused_action_el)
     let old_text = window.prompt(_T('dlgpTextToReplace'));
     if(old_text === null) return;   // user cancelled
 
-    let new_text = window.prompt(_T('dlgpReplacementText'));
+    let new_text = window.prompt(_T('dlgpReplacementText'), old_text);
     if(new_text === null) return;   // user cancelled
 
     if(!old_text) return;   // search pattern is required


### PR DESCRIPTION
This makes it easier to make a small change.  It will also serve as a
handy reference for the capturing groups in your regex ($1, $2, ...).